### PR TITLE
solve issue #5

### DIFF
--- a/mtrain/evaluator.py
+++ b/mtrain/evaluator.py
@@ -166,7 +166,7 @@ class Evaluator(object):
         Computes BLEU scores with internal tokenization, output identical
         to multi-bleu-detok.perl.
         """
-        multibleu_command = '{script} {reference_path} < {hypothesis_path} > {output_path}'.format(
+        multibleu_command = '{script} {reference_path} < {hypothesis} > {output_path}'.format(
             script=C.MULTIBLEU_DETOK_TOOL,
             reference_path=reference_path,
             hypothesis=hypothesis_path,


### PR DESCRIPTION
The change solves issue #5 by renaming the format-dict key 'hypothesis_path' to 'hypothesis', analogue to the code block implementing multeval evaluation.